### PR TITLE
Bug id 30/the order or purchase order identifier is confusing to the user

### DIFF
--- a/backend/models/orderModel.js
+++ b/backend/models/orderModel.js
@@ -2,7 +2,6 @@ import mongoose from 'mongoose';
 
 const orderSchema = new mongoose.Schema(
   {
-    orderID: { type: Number, required: true, unique: true },
     orderItems: [
       {
         slug: { type: String, required: false },
@@ -43,7 +42,9 @@ const orderSchema = new mongoose.Schema(
   }
 );
 
+// Middleware para incrementar el orderID antes de guardar
 orderSchema.pre('save', function (next) {
+  // 'this' hace referencia a la instancia actual del documento
   if (!this.orderID) {
     // Incrementar el orderID en 1
     Order.countDocuments({}, (err, count) => {

--- a/backend/models/orderModel.js
+++ b/backend/models/orderModel.js
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 
 const orderSchema = new mongoose.Schema(
   {
+    orderID: { type: Number, required: true, unique: true },
     orderItems: [
       {
         slug: { type: String, required: false },
@@ -41,6 +42,21 @@ const orderSchema = new mongoose.Schema(
     timestamps: true,
   }
 );
+
+orderSchema.pre('save', function (next) {
+  if (!this.orderID) {
+    // Incrementar el orderID en 1
+    Order.countDocuments({}, (err, count) => {
+      if (err) {
+        return next(err);
+      }
+      this.orderID = count + 1;
+      next();
+    });
+  } else {
+    next();
+  }
+});
 
 const Order = mongoose.model('Order', orderSchema);
 export default Order;

--- a/frontend/src/screens/OrderHistoryScreen.js
+++ b/frontend/src/screens/OrderHistoryScreen.js
@@ -74,7 +74,7 @@ export default function OrderHistoryScreen() {
           <tbody>
             {orders.map((order) => (
               <tr key={order._id}>
-                <td>{order._id}</td>
+                <td>{order.NumberProduct}</td>
                 <td>{order.createdAt ? format(new Date(order.createdAt), 'yyyy-MM-dd') : 'Invalid Date'}</td>       
                 <td>{order.itemsPrice ? order.itemsPrice.toFixed(2) : 'N/A'}</td>    
                 <td>

--- a/frontend/src/screens/OrderHistoryScreen.js
+++ b/frontend/src/screens/OrderHistoryScreen.js
@@ -74,7 +74,7 @@ export default function OrderHistoryScreen() {
           <tbody>
             {orders.map((order) => (
               <tr key={order._id}>
-                <td>{order.NumberProduct}</td>
+                <td>Order {' '} {order.NumberProduct}</td>
                 <td>{order.createdAt ? format(new Date(order.createdAt), 'yyyy-MM-dd') : 'Invalid Date'}</td>       
                 <td>{order.itemsPrice ? order.itemsPrice.toFixed(2) : 'N/A'}</td>    
                 <td>

--- a/frontend/src/screens/OrderScreen.js
+++ b/frontend/src/screens/OrderScreen.js
@@ -74,7 +74,7 @@ export default function OrderScreen() {
       </Helmet>
       <h2 className="my-3"> Information about your order </h2>
       <h6>
-  <span style={{ fontWeight: 'bold' }}>ID:</span> {orderId}
+  <span style={{ fontWeight: 'bold' }}>ID:</span> {order.NumberProduct}
 </h6>
 <h6>
   <span style={{ fontWeight: 'bold' }}>Date:</span>{' '}

--- a/frontend/src/screens/OrderScreen.js
+++ b/frontend/src/screens/OrderScreen.js
@@ -74,7 +74,8 @@ export default function OrderScreen() {
       </Helmet>
       <h2 className="my-3"> Information about your order </h2>
       <h6>
-  <span style={{ fontWeight: 'bold' }}>ID:</span> {order.NumberProduct}
+      <span style={{ fontWeight: 'bold' }}>ID:</span> Order {' '}{order.NumberProduct}
+
 </h6>
 <h6>
   <span style={{ fontWeight: 'bold' }}>Date:</span>{' '}

--- a/frontend/src/screens/OrderScreen.js
+++ b/frontend/src/screens/OrderScreen.js
@@ -51,7 +51,7 @@ export default function OrderScreen() {
         const { data } = await axios.get(`/api/orders/${orderId}`, {
           headers: { authorization: `Bearer ${userInfo.token}` }
         });
-        console.log('Order Data:', data); // Agrega esta línea
+        console.log('Order Data:', data); // Agrega s línea
         dispatch({ type: 'FETCH_SUCCESS', payload: data });
       } catch (err) {
         dispatch({ type: 'FETCH_FAIL', payload: getError(err) });


### PR DESCRIPTION
The following bug was fixed:
Description: When accessing the purchase history, the system generates a confusing identifier for each order. Instead of displaying a user-friendly identifier, the system seems to use identifiers that resemble MongoDB IDs or similar formats, causing confusion for users. They are recommended to use an index format.

Expected Result:
The system should generate a non-confusing identifier for each order in the purchase history. The identifier should be user-friendly, easy to understand, and not resemble database-specific IDs like those used in MongoDB.
Current Result:
The system generates identifiers that appear to be in a format similar to MongoDB or other database IDs. This format is not user-friendly and can cause confusion for users trying to understand and track their orders in the purchase history.