### PR TITLE
Bug id 29/the currency type is not displayed in the total field

### DIFF
--- a/frontend/src/screens/OrderHistoryScreen.js
+++ b/frontend/src/screens/OrderHistoryScreen.js
@@ -76,7 +76,7 @@ export default function OrderHistoryScreen() {
               <tr key={order._id}>
                 <td>{order._id}</td>
                 <td>{order.createdAt ? format(new Date(order.createdAt), 'yyyy-MM-dd') : 'Invalid Date'}</td>       
-                <td>${order.itemsPrice ? order.itemsPrice.toFixed(2) : 'N/A'}</td>    
+                <td>${' '}{order.itemsPrice ? order.itemsPrice.toFixed(2) : 'N/A'}</td>    
                 <td>
                   <Button
                     type="button"

--- a/frontend/src/screens/OrderHistoryScreen.js
+++ b/frontend/src/screens/OrderHistoryScreen.js
@@ -76,7 +76,7 @@ export default function OrderHistoryScreen() {
               <tr key={order._id}>
                 <td>{order._id}</td>
                 <td>{order.createdAt ? format(new Date(order.createdAt), 'yyyy-MM-dd') : 'Invalid Date'}</td>       
-                <td>{order.itemsPrice ? order.itemsPrice.toFixed(2) : 'N/A'}</td>    
+                <td>${order.itemsPrice ? order.itemsPrice.toFixed(2) : 'N/A'}</td>    
                 <td>
                   <Button
                     type="button"

--- a/frontend/src/screens/OrderScreen.js
+++ b/frontend/src/screens/OrderScreen.js
@@ -107,10 +107,10 @@ export default function OrderScreen() {
                       <span>{item.quantity}</span>
                     </Col>
                     <Col md={2} className="text-left">
-                      ${item.price }
+                      ${' '}{item.price }
                     </Col>
                     <Col md={2} className="text-left">
-                      ${(item.price * item.quantity)}
+                      ${' '}{(item.price * item.quantity)}
                     </Col>
                   </Row>
                 </ListGroup.Item>
@@ -128,7 +128,7 @@ export default function OrderScreen() {
         <ListGroup.Item>
           <Row>
             <Col className="text-left" style={{ textAlign: 'left' }}>Items</Col>
-            <Col className="text-right" style={{ textAlign: 'right' }}>${order.itemsPrice.toFixed(2)}</Col>
+            <Col className="text-right" style={{ textAlign: 'right' }}>${' '}{order.itemsPrice.toFixed(2)}</Col>
           </Row>
         </ListGroup.Item>
         <ListGroup.Item>
@@ -143,7 +143,7 @@ export default function OrderScreen() {
               <strong>Order Total</strong>
             </Col>
             <Col className="text-right" style={{ textAlign: 'right' }}>
-              <strong>${order.itemsPrice.toFixed(2)}</strong>
+              <strong>${' '}{order.itemsPrice.toFixed(2)}</strong>
             </Col>
           </Row>
         </ListGroup.Item>


### PR DESCRIPTION
The following bug was fixed:
Description: The currency identifier is not displayed in the Total field as expected. Users are unable to visualize the type of currency used for their payments, leading to a lack of information and awareness regarding their financial transactions.
Expected Result:
The Total field in the purchase history table should display the type of currency used for the payment, such as the dollar sign [$] or a relevant identifier. This information is crucial for users to be informed and aware of their financial actions.
Current Result:
The Total field in the purchase history table does not show any currency identifier. It only displays the numerical value without indicating the type of currency used for the respective payment, resulting in users being uninformed about the currency associated with their transactions.