### PR TITLE
delete buttons of paypal and stripe

### DIFF
--- a/frontend/src/screens/ShippingAddressScreen.js
+++ b/frontend/src/screens/ShippingAddressScreen.js
@@ -88,7 +88,6 @@ export default function ShippingAddressScreen() {
 
   if (!areRequiredFieldsFilled) {
     console.log('Please complete all required fields except Nit.');
-    // Aquí puedes mostrar un mensaje al usuario indicando que todos los campos requeridos, excepto Nit, deben estar completos
     return;
   }
 
@@ -278,38 +277,7 @@ export default function ShippingAddressScreen() {
                         <CartScreen2/>
                       </div>
                       <div>
-                      
-                      <ListGroup variant="flush">
-                        
-                        <ListGroup.Item className='gray-background'>
-                          <div className="mb-3">
-                            <Form.Check
-                              type="radio"
-                              id="PayPal"
-                              label="PayPal"
-                              value="PayPal"
-                              checked={paymentMethodName === 'PayPal'}
-                              onChange={(e) => setPaymentMethod(e.target.value)}
-                              disabled={true} 
-                            />
-                          </div>
-                        </ListGroup.Item>
-                        
-                        <ListGroup.Item className='gray-background'>
-                          <div className="mb-3">
-                            <Form.Check
-                              type="radio"
-                              id="Stripe"
-                              label="Stripe"
-                              value="Stripe"
-                              checked={paymentMethodName === 'Stripe'}
-                              onChange={(e) => setPaymentMethod(e.target.value)}
-                            />
-                          </div>
-                        </ListGroup.Item>
-                      </ListGroup>
                       </div>
-                      
                       <div className="d-flex justify-content-end mt-3">
                       <Button variant="primary" type="submit" onClick={placeOrder}>Place the Order</Button>
       </div>


### PR DESCRIPTION
Description:
On the Billing Details page there are 2 options as payment methods, and the default option is PayPal, when filling in the required information and clicking on "Place the Order" with the paypayl option selected, the user is allowed to proceed with the purchase even if there is no PayPal API integrated in the website.
Severity: 
High
Steps to Reproduce:
Go to link: https://frontend-petshoptest.onrender.com/
Add a product to cart
Click on the      shopping cart icon on the header
You will be      redirected to the shopping page. 
Click on the      "Payment" button
You will be      redirected to the Billing Details page.
Correctly fill in      all the fields requested (Full Name, Address, City, Cell Phone).
In the payment      method, keep the default option selected (PayPal)
Click the      "place the order" button
The checkout      process will continue, but with the stripe API even though the      "PayPal" payment option was selected.
Expected Result:
It should not be possible to select PayPal as a payment method, as there is no API integrated with this service on the web.
Actual Result:
The user can keep PayPal selected as payment method, even though there is no support for paypal payments.
Browser:
Chrome version 117.0.5938.92 (Official Build) (64-bit)
Operating System:
Windows 10